### PR TITLE
WIP: Add default many-to-many support

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -18,8 +18,9 @@ Authors
 - Ben Lawson (`blawson <https://github.com/blawson>`_)
 - `bradford281 <https://github.com/bradford281>`_
 - Brian Armstrong (`barm <https://github.com/barm>`_)
-- Buddy Lindsey, Jr.
 - Brian Dixon
+- Brian Mesick (`bmedx <https://github.com/bmedx>`_)
+- Buddy Lindsey, Jr.
 - Christopher Broderick (`uhurusurfa <https://github.com/uhurusurfa>`_)
 - Corey Bertram
 - Craig Maloney (`craigmaloney <https://github.com/craigmaloney>`_)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Unreleased
 ----------
 - Add simple filtering if provided a minutes argument in `clean_duplicate_history` (gh-606)
+- Add basic support for many-to-many fields (gh-399)
 
 2.8.0 (2019-12-02)
 ------------------

--- a/simple_history/manager.py
+++ b/simple_history/manager.py
@@ -121,35 +121,3 @@ class HistoryManager(models.Manager):
         return self.model.objects.bulk_create(
             historical_instances, batch_size=batch_size
         )
-
-
-class M2MHistoryDescriptor(object):
-    def __init__(self, model):
-        self.model = model
-
-    def __get__(self, instance, owner):
-        if instance is None:
-            return M2MHistoryManager(self.model)
-        return M2MHistoryManager(self.model, instance)
-
-
-class M2MHistoryManager(models.Manager):
-    def __init__(self, model, instance=None):
-        super(M2MHistoryManager, self).__init__()
-        self.model = model
-        self.instance = instance
-
-    def get_super_queryset(self):
-        return super(M2MHistoryManager, self).get_queryset()
-
-    def get_queryset(self):
-        qs = self.get_super_queryset()
-
-        if self.instance is None:
-            return qs
-
-        if isinstance(self.instance._meta.pk, models.ForeignKey):
-            key_name = self.instance._meta.pk.name + "_id"
-        else:
-            key_name = self.instance._meta.pk.name
-        return self.get_super_queryset().filter(**{key_name: self.instance.pk})

--- a/simple_history/manager.py
+++ b/simple_history/manager.py
@@ -121,3 +121,35 @@ class HistoryManager(models.Manager):
         return self.model.objects.bulk_create(
             historical_instances, batch_size=batch_size
         )
+
+
+class M2MHistoryDescriptor(object):
+    def __init__(self, model):
+        self.model = model
+
+    def __get__(self, instance, owner):
+        if instance is None:
+            return M2MHistoryManager(self.model)
+        return M2MHistoryManager(self.model, instance)
+
+
+class M2MHistoryManager(models.Manager):
+    def __init__(self, model, instance=None):
+        super(M2MHistoryManager, self).__init__()
+        self.model = model
+        self.instance = instance
+
+    def get_super_queryset(self):
+        return super(M2MHistoryManager, self).get_queryset()
+
+    def get_queryset(self):
+        qs = self.get_super_queryset()
+
+        if self.instance is None:
+            return qs
+
+        if isinstance(self.instance._meta.pk, models.ForeignKey):
+            key_name = self.instance._meta.pk.name + "_id"
+        else:
+            key_name = self.instance._meta.pk.name
+        return self.get_super_queryset().filter(**{key_name: self.instance.pk})

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -218,6 +218,9 @@ class HistoricalRecords(object):
     def create_history_m2m_model(self, model, through_model):
         attrs = {
             "__module__": self.module,
+            "__str__": lambda self: "{} as of {}".format(
+                self._meta.verbose_name, self.history.history_date
+            ),
         }
 
         app_module = "%s.models" % model._meta.app_label

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -574,7 +574,9 @@ class HistoricalRecords(object):
                 insert_row = {'history': history_instance}
 
                 for through_model_field in through_model._meta.fields:
-                    insert_row[through_model_field.name] = getattr(row,  through_model_field.name)
+                    insert_row[through_model_field.name] = getattr(
+                        row, through_model_field.name
+                    )
 
                 m2m_history_model.objects.create(**insert_row)
 

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -231,17 +231,21 @@ class HistoricalRecords(object):
             attrs["__module__"] = models_module
 
         # Get the primary key to the history model this model will look up to
-        attrs['history'] = models.ForeignKey(
+        attrs["m2m_history_id"] = self._get_history_id_field()
+        attrs["history"] = models.ForeignKey(
             model,
             db_constraint=False,
             on_delete=models.DO_NOTHING,
         )
 
-        for field in through_model._meta.fields:
+        """for field in through_model._meta.fields:
             f = copy.copy(field)
             if isinstance(f, models.ForeignKey):
                 f.__class__ = models.BigIntegerField
             attrs[f.name + '_id'] = f
+        """
+        fields = self.copy_fields(through_model)
+        attrs.update(fields)
 
         # Set as the default then check for overrides
         name = self.get_history_model_name(through_model)
@@ -257,13 +261,11 @@ class HistoricalRecords(object):
 
         history_model = type(str(name), (models.Model,), attrs)
 
-        foo = (
+        return (
             python_2_unicode_compatible(history_model)
             if django.VERSION < (2,)
             else history_model
         )
-
-        return foo
 
     def create_history_model(self, model, inherited):
         """
@@ -394,20 +396,6 @@ class HistoricalRecords(object):
             )
         else:
             history_id_field = models.AutoField(primary_key=True)
-
-        return history_id_field
-
-    def _get_m2m_history_id_field(self):
-        if self.history_id_field:
-            history_id_field = self.history_id_field
-            history_id_field.primary_key = False
-            history_id_field.editable = False
-        elif getattr(settings, "SIMPLE_HISTORY_HISTORY_ID_USE_UUID", False):
-            history_id_field = models.UUIDField(
-                primary_key=False, default=uuid.uuid4, editable=False
-            )
-        else:
-            history_id_field = models.BigIntegerField(editable=False)
 
         return history_id_field
 
@@ -586,8 +574,7 @@ class HistoricalRecords(object):
                 insert_row = {'history': history_instance}
 
                 for through_model_field in through_model._meta.fields:
-                    if isinstance(through_model_field, models.ForeignKey):
-                        insert_row[through_model_field.name] = getattr(row,  through_model_field.name).pk
+                    insert_row[through_model_field.name] = getattr(row,  through_model_field.name)
 
                 m2m_history_model.objects.create(**insert_row)
 

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -5,6 +5,7 @@ import importlib
 import threading
 import uuid
 import warnings
+from functools import partial
 
 import django
 import six
@@ -16,6 +17,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.db.models import Q
 from django.db.models.fields.proxy import OrderWrt
+from django.db.models.signals import m2m_changed
 from django.forms.models import model_to_dict
 from django.urls import reverse
 from django.utils.text import format_lazy
@@ -81,6 +83,7 @@ class HistoricalRecords(object):
         history_user_setter=_history_user_setter,
         related_name=None,
         use_base_model_db=False,
+        m2m_fields=(),
     ):
         self.user_set_verbose_name = verbose_name
         self.user_related_name = user_related_name
@@ -98,6 +101,7 @@ class HistoricalRecords(object):
         self.user_setter = history_user_setter
         self.related_name = related_name
         self.use_base_model_db = use_base_model_db
+        self.m2m_fields = m2m_fields
 
         if excluded_fields is None:
             excluded_fields = []
@@ -164,6 +168,9 @@ class HistoricalRecords(object):
         # so the signal handlers can't use weak references.
         models.signals.post_save.connect(self.post_save, sender=sender, weak=False)
         models.signals.post_delete.connect(self.post_delete, sender=sender, weak=False)
+        for field in self.m2m_fields:
+            m2m_changed.connect(partial(self.m2m_changed, attr=field.name),
+                                sender=field.remote_field.through, weak=False)
 
         descriptor = HistoryDescriptor(history_model)
         setattr(sender, self.manager_name, descriptor)
@@ -363,6 +370,12 @@ class HistoricalRecords(object):
         else:
             return {}
 
+    def _get_many_to_many_fields(self):
+        fields = {}
+        for field in self.m2m_fields:
+            fields[field.name] = models.ManyToManyField(field.remote_field.model)
+        return fields
+
     def get_extra_fields(self, model, fields):
         """Return dict of extra fields added to the historical record model"""
 
@@ -441,6 +454,7 @@ class HistoricalRecords(object):
 
         extra_fields.update(self._get_history_related_field(model))
         extra_fields.update(self._get_history_user_fields())
+        extra_fields.update(self._get_many_to_many_fields())
 
         return extra_fields
 
@@ -474,6 +488,29 @@ class HistoricalRecords(object):
             manager.using(using).all().delete()
         else:
             self.create_historical_record(instance, "-", using=using)
+
+    def m2m_changed(self, instance, action, attr, pk_set, reverse, **_):
+        if reverse:
+            # TODO - Reverse m2m update does not work
+            # HistoricalModel contains the ManyToManyField, so this call
+            # modifies the reverse relation
+            return
+
+        if hasattr(instance, 'skip_history_when_saving'):
+            historical = instance.history.latest()
+        else:
+            # TODO - m2m update should create new version
+            # Currently updates latest version, but in fact should create new one
+            historical = None
+
+        field = getattr(historical, attr)
+
+        if action == 'post_add':
+            field.add(*pk_set)
+        if action == 'post_remove':
+            field.remove(*pk_set)
+        if action == 'post_clear':
+            field.clear()
 
     def create_historical_record(self, instance, history_type, using=None):
         using = using if self.use_base_model_db else None

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -171,8 +171,11 @@ class HistoricalRecords(object):
         models.signals.post_save.connect(self.post_save, sender=sender, weak=False)
         models.signals.post_delete.connect(self.post_delete, sender=sender, weak=False)
         for field in self.m2m_fields:
-            m2m_changed.connect(partial(self.m2m_changed, attr=field.name),
-                                sender=field.remote_field.through, weak=False)
+            m2m_changed.connect(
+                partial(self.m2m_changed, attr=field.name),
+                sender=field.remote_field.through,
+                weak=False,
+            )
 
         descriptor = HistoryDescriptor(history_model)
         setattr(sender, self.manager_name, descriptor)
@@ -180,8 +183,7 @@ class HistoricalRecords(object):
 
         for field in self.m2m_fields:
             m2m_model = self.create_history_m2m_model(
-                history_model,
-                field.remote_field.through
+                history_model, field.remote_field.through
             )
             self.m2m_models[field] = m2m_model
 
@@ -232,19 +234,14 @@ class HistoricalRecords(object):
         # Get the primary key to the history model this model will look up to
         attrs["m2m_history_id"] = self._get_history_id_field()
         attrs["history"] = models.ForeignKey(
-            model,
-            db_constraint=False,
-            on_delete=models.DO_NOTHING,
+            model, db_constraint=False, on_delete=models.DO_NOTHING,
         )
 
         fields = self.copy_fields(through_model)
         attrs.update(fields)
 
-        # Set as the default then check for overrides
         name = self.get_history_model_name(through_model)
-
         registered_models[through_model._meta.db_table] = through_model
-
         meta_fields = {"verbose_name": name}
 
         if self.app:
@@ -252,12 +249,12 @@ class HistoricalRecords(object):
 
         attrs.update(Meta=type(str("Meta"), (), meta_fields))
 
-        history_model = type(str(name), (models.Model,), attrs)
+        m2m_history_model = type(str(name), (models.Model,), attrs)
 
         return (
-            python_2_unicode_compatible(history_model)
+            python_2_unicode_compatible(m2m_history_model)
             if django.VERSION < (2,)
-            else history_model
+            else m2m_history_model
         )
 
     def create_history_model(self, model, inherited):
@@ -267,7 +264,7 @@ class HistoricalRecords(object):
         attrs = {
             "__module__": self.module,
             "_history_excluded_fields": self.excluded_fields,
-            "_history_m2m_fields": self.m2m_fields
+            "_history_m2m_fields": self.m2m_fields,
         }
 
         app_module = "%s.models" % model._meta.app_label
@@ -549,7 +546,7 @@ class HistoricalRecords(object):
         if hasattr(instance, "skip_history_when_saving"):
             return
 
-        if action in ('post_add', 'post_remove', 'post_clear'):
+        if action in ("post_add", "post_remove", "post_clear"):
             # It should be safe to ~ this since the row must exist to modify m2m on it
             self.create_historical_record(instance, "~")
 
@@ -563,12 +560,10 @@ class HistoricalRecords(object):
 
             through_field_name = type(original_instance).__name__.lower()
 
-            rows = through_model.objects.filter(
-                **{through_field_name: instance}
-            )
+            rows = through_model.objects.filter(**{through_field_name: instance})
 
             for row in rows:
-                insert_row = {'history': history_instance}
+                insert_row = {"history": history_instance}
 
                 for through_model_field in through_model._meta.fields:
                     insert_row[through_model_field.name] = getattr(

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -24,7 +24,7 @@ from django.utils.text import format_lazy
 from django.utils.timezone import now
 from simple_history import utils
 from . import exceptions
-from .manager import HistoryDescriptor
+from .manager import HistoryDescriptor, M2MHistoryDescriptor
 from .signals import post_create_historical_record, pre_create_historical_record
 
 if django.VERSION < (2,):
@@ -62,6 +62,7 @@ def _history_user_setter(historical_instance, user):
 
 class HistoricalRecords(object):
     thread = threading.local()
+    m2m_models = {}
 
     def __init__(
         self,
@@ -157,6 +158,7 @@ class HistoricalRecords(object):
                 )
             )
         history_model = self.create_history_model(sender, inherited)
+
         if inherited:
             # Make sure history model is in same module as concrete model
             module = importlib.import_module(history_model.__module__)
@@ -175,6 +177,20 @@ class HistoricalRecords(object):
         descriptor = HistoryDescriptor(history_model)
         setattr(sender, self.manager_name, descriptor)
         sender._meta.simple_history_manager_attribute = self.manager_name
+
+        for field in self.m2m_fields:
+            m2m_model = self.create_history_m2m_model(
+                history_model,
+                field.remote_field.through
+            )
+            self.m2m_models[field] = m2m_model
+
+            module = importlib.import_module(self.module)
+            setattr(module, m2m_model.__name__, m2m_model)
+
+            m2m_descriptor = M2MHistoryDescriptor(m2m_model)
+            setattr(sender, "historical_{}".format(field.name), m2m_descriptor)
+            setattr(history_model, "historical_{}".format(field.name), m2m_descriptor)
 
     def get_history_model_name(self, model):
         if not self.custom_model_name:
@@ -197,6 +213,57 @@ class HistoricalRecords(object):
                 self.custom_model_name
             )
         )
+
+    def create_history_m2m_model(self, model, through_model):
+        attrs = {
+            "__module__": self.module,
+        }
+
+        app_module = "%s.models" % model._meta.app_label
+
+        if model.__module__ != self.module:
+            # registered under different app
+            attrs["__module__"] = self.module
+        elif app_module != self.module:
+            # Abuse an internal API because the app registry is loading.
+            app = apps.app_configs[model._meta.app_label]
+            models_module = app.name
+            attrs["__module__"] = models_module
+
+        # Get the primary key to the history model this model will look up to
+        attrs['history'] = models.ForeignKey(
+            model,
+            db_constraint=False,
+            on_delete=models.DO_NOTHING,
+        )
+
+        for field in through_model._meta.fields:
+            f = copy.copy(field)
+            if isinstance(f, models.ForeignKey):
+                f.__class__ = models.BigIntegerField
+            attrs[f.name + '_id'] = f
+
+        # Set as the default then check for overrides
+        name = self.get_history_model_name(through_model)
+
+        registered_models[through_model._meta.db_table] = through_model
+
+        meta_fields = {"verbose_name": name}
+
+        if self.app:
+            meta_fields["app_label"] = self.app
+
+        attrs.update(Meta=type(str("Meta"), (), meta_fields))
+
+        history_model = type(str(name), (models.Model,), attrs)
+
+        foo = (
+            python_2_unicode_compatible(history_model)
+            if django.VERSION < (2,)
+            else history_model
+        )
+
+        return foo
 
     def create_history_model(self, model, inherited):
         """
@@ -330,6 +397,20 @@ class HistoricalRecords(object):
 
         return history_id_field
 
+    def _get_m2m_history_id_field(self):
+        if self.history_id_field:
+            history_id_field = self.history_id_field
+            history_id_field.primary_key = False
+            history_id_field.editable = False
+        elif getattr(settings, "SIMPLE_HISTORY_HISTORY_ID_USE_UUID", False):
+            history_id_field = models.UUIDField(
+                primary_key=False, default=uuid.uuid4, editable=False
+            )
+        else:
+            history_id_field = models.BigIntegerField(editable=False)
+
+        return history_id_field
+
     def _get_history_user_fields(self):
         if self.user_id_field is not None:
             # Tracking user using explicit id rather than Django ForeignKey
@@ -373,7 +454,7 @@ class HistoricalRecords(object):
     def _get_many_to_many_fields(self):
         fields = {}
         for field in self.m2m_fields:
-            fields[field.name] = models.ManyToManyField(field.remote_field.model)
+            fields[field.name] = models.ManyToManyField(self.m2m_models[field])
         return fields
 
     def get_extra_fields(self, model, fields):
@@ -454,7 +535,7 @@ class HistoricalRecords(object):
 
         extra_fields.update(self._get_history_related_field(model))
         extra_fields.update(self._get_history_user_fields())
-        extra_fields.update(self._get_many_to_many_fields())
+        # extra_fields.update(self._get_many_to_many_fields())
 
         return extra_fields
 
@@ -490,27 +571,25 @@ class HistoricalRecords(object):
             self.create_historical_record(instance, "-", using=using)
 
     def m2m_changed(self, instance, action, attr, pk_set, reverse, **_):
-        if reverse:
-            # TODO - Reverse m2m update does not work
-            # HistoricalModel contains the ManyToManyField, so this call
-            # modifies the reverse relation
-            return
+        if action in ('post_add', 'post_remove', 'post_clear'):
+            self.create_historical_record(instance, "~")
 
-        if hasattr(instance, 'skip_history_when_saving'):
-            historical = instance.history.latest()
-        else:
-            # TODO - m2m update should create new version
-            # Currently updates latest version, but in fact should create new one
-            historical = None
+    def create_historical_record_m2ms(self, history_instance, instance):
+        for field in self.m2m_fields:
+            m2m_history_model = self.m2m_models[field]
+            original_instance = history_instance.instance
+            through_model = getattr(original_instance, field.name).through
 
-        field = getattr(historical, attr)
+            rows = through_model.objects.all()
 
-        if action == 'post_add':
-            field.add(*pk_set)
-        if action == 'post_remove':
-            field.remove(*pk_set)
-        if action == 'post_clear':
-            field.clear()
+            for row in rows:
+                insert_row = {'history': history_instance}
+
+                for through_model_field in through_model._meta.fields:
+                    if isinstance(through_model_field, models.ForeignKey):
+                        insert_row[through_model_field.name] = getattr(row,  through_model_field.name).pk
+
+                m2m_history_model.objects.create(**insert_row)
 
     def create_historical_record(self, instance, history_type, using=None):
         using = using if self.use_base_model_db else None
@@ -546,6 +625,7 @@ class HistoricalRecords(object):
         )
 
         history_instance.save(using=using)
+        self.create_historical_record_m2ms(history_instance, instance)
 
         post_create_historical_record.send(
             sender=manager.model,

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -91,9 +91,9 @@ class PollWithManyToMany(models.Model):
 class PollWithSeveralManyToMany(models.Model):
     question = models.CharField(max_length=200)
     pub_date = models.DateTimeField("date published")
-    places = models.ManyToManyField("Place", related_name='places_poll')
-    restaurants = models.ManyToManyField("Restaurant", related_name='restaurants_poll')
-    books = models.ManyToManyField("Book", related_name='books_poll')
+    places = models.ManyToManyField("Place", related_name="places_poll")
+    restaurants = models.ManyToManyField("Restaurant", related_name="restaurants_poll")
+    books = models.ManyToManyField("Book", related_name="books_poll")
 
     history = HistoricalRecords(m2m_fields=[places, restaurants, books])
 

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -87,8 +87,15 @@ class PollWithManyToMany(models.Model):
 
     history = HistoricalRecords(m2m_fields=[places])
 
-    def get_absolute_url(self):
-        return reverse("poll-detail", kwargs={"pk": self.pk})
+
+class PollWithSeveralManyToMany(models.Model):
+    question = models.CharField(max_length=200)
+    pub_date = models.DateTimeField("date published")
+    places = models.ManyToManyField("Place", related_name='places_poll')
+    restaurants = models.ManyToManyField("Restaurant", related_name='restaurants_poll')
+    books = models.ManyToManyField("Book", related_name='books_poll')
+
+    history = HistoricalRecords(m2m_fields=[places, restaurants, books])
 
 
 class CustomAttrNameForeignKey(models.ForeignKey):

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -80,6 +80,17 @@ class PollWithHistoricalIPAddress(models.Model):
         return reverse("poll-detail", kwargs={"pk": self.pk})
 
 
+class PollWithManyToMany(models.Model):
+    question = models.CharField(max_length=200)
+    pub_date = models.DateTimeField("date published")
+    places = models.ManyToManyField("Place")
+
+    history = HistoricalRecords(m2m_fields=[places])
+
+    def get_absolute_url(self):
+        return reverse("poll-detail", kwargs={"pk": self.pk})
+
+
 class CustomAttrNameForeignKey(models.ForeignKey):
     def __init__(self, *args, **kwargs):
         self.attr_name = kwargs.pop("attr_name", None)

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -81,6 +81,7 @@ from ..models import (
     PollWithExcludedFKField,
     PollWithHistoricalIPAddress,
     PollWithManyToMany,
+    PollWithSeveralManyToMany,
     HistoricalPollWithManyToMany_places,
     Province,
     Restaurant,
@@ -1482,6 +1483,46 @@ class ForeignKeyToSelfTest(TestCase):
         self.assertEqual(
             self.model, self.history_model.fk_to_self_using_str.field.remote_field.model
         )
+
+
+class SeveralManyToManyTest(TestCase):
+    def setUp(self):
+        self.model = PollWithSeveralManyToMany
+        self.history_model = self.model.history.model
+        self.place = Place.objects.create(name="Home")
+        self.book = Book.objects.create(isbn="1234")
+        self.restaurant = Restaurant.objects.create(rating=1)
+        self.poll = PollWithSeveralManyToMany.objects.create(
+            question="what's up?", pub_date=today
+        )
+
+    def test_separation(self):
+        self.assertEqual(self.poll.history.all().count(), 1)
+        self.poll.places.add(self.place)
+        self.poll.books.add(self.book)
+        self.poll.restaurants.add(self.restaurant)
+        self.assertEqual(self.poll.history.all().count(), 4)
+
+        restaurant, book, place, add = self.poll.history.all()
+
+        self.assertEqual(restaurant.restaurants.all().count(), 1)
+        self.assertEqual(restaurant.books.all().count(), 1)
+        self.assertEqual(restaurant.places.all().count(), 1)
+        self.assertEqual(restaurant.restaurants.first().restaurant, self.restaurant)
+
+        self.assertEqual(book.restaurants.all().count(), 0)
+        self.assertEqual(book.books.all().count(), 1)
+        self.assertEqual(book.places.all().count(), 1)
+        self.assertEqual(book.books.first().book, self.book)
+
+        self.assertEqual(place.restaurants.all().count(), 0)
+        self.assertEqual(place.books.all().count(), 0)
+        self.assertEqual(place.places.all().count(), 1)
+        self.assertEqual(place.places.first().place, self.place)
+
+        self.assertEqual(add.restaurants.all().count(), 0)
+        self.assertEqual(add.books.all().count(), 0)
+        self.assertEqual(add.places.all().count(), 0)
 
 
 class ManyToManyTest(TestCase):

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -1656,12 +1656,9 @@ class ManyToManyTest(TestCase):
 
         # But the values persist
         historical_place_values = m2m_record.places.all().values()[0]
-        self.assertEqual(historical_place_values['history_id'], m2m_record.history_id)
-        self.assertEqual(historical_place_values['place_id'], original_place_id)
-        self.assertEqual(
-            historical_place_values['pollwithmanytomany_id'],
-            self.poll.id
-        )
+        self.assertEqual(historical_place_values["history_id"], m2m_record.history_id)
+        self.assertEqual(historical_place_values["place_id"], original_place_id)
+        self.assertEqual(historical_place_values["pollwithmanytomany_id"], self.poll.id)
 
     def test_delete_parent(self):
         # Add a place

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -1611,7 +1611,7 @@ class ManyToManyTest(TestCase):
         # Place instance cannot be created...
         historical_place = m2m_record.historical_places.first()
         with self.assertRaises(ObjectDoesNotExist):
-            x = historical_place.place.id
+            historical_place.place.id
 
         # But the values persist
         historical_place_values = m2m_record.historical_places.all().values()[0]
@@ -1684,9 +1684,9 @@ class ManyToManyTest(TestCase):
 
     def test_bulk_add_remove(self):
         # Add some places
-        place_2 = Place.objects.create(name="Place 2")
-        place_3 = Place.objects.create(name="Place 3")
-        place_4 = Place.objects.create(name="Place 4")
+        Place.objects.create(name="Place 2")
+        Place.objects.create(name="Place 3")
+        Place.objects.create(name="Place 4")
 
         # Bulk add all of the places
         self.poll.places.add(*Place.objects.all())

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -1522,10 +1522,10 @@ class ManyToManyTest(TestCase):
         )
         self.assertDatetimesEqual(record.history_date, datetime.now())
 
-        historical_poll = self.poll.history.most_recent()
+        historical_poll = self.poll.history.all()[0]
 
         # There should be no places associated with the current poll yet
-        self.assertEqual(historical_poll.historical_places.count(), 0)
+        self.assertEqual(historical_poll.places.count(), 0)
 
         # Add a many-to-many child
         self.poll.places.add(self.place)
@@ -1534,11 +1534,11 @@ class ManyToManyTest(TestCase):
         self.assertEqual(self.poll.history.all().count(), 2)
 
         # The new row has a place attached to it
-        m2m_record = self.poll.history.most_recent()
+        m2m_record = self.poll.history.all()[0]
         self.assertEqual(m2m_record.places.count(), 1)
 
         # And the historical place is the correct one
-        historical_place = m2m_record.historical_places.first()
+        historical_place = m2m_record.places.first()
         self.assertEqual(historical_place.place, self.place)
 
     def test_remove(self):
@@ -1551,14 +1551,14 @@ class ManyToManyTest(TestCase):
 
         # The newest row has no place attached to it
         m2m_record = self.poll.history.all()[0]
-        self.assertEqual(m2m_record.historical_places.count(), 0)
+        self.assertEqual(m2m_record.places.count(), 0)
 
         # The previous one should have one place
         previous_m2m_record = m2m_record.prev_record
-        self.assertEqual(previous_m2m_record.historical_places.count(), 1)
+        self.assertEqual(previous_m2m_record.places.count(), 1)
 
         # And the previous row still has the correct one
-        historical_place = previous_m2m_record.historical_places.first()
+        historical_place = previous_m2m_record.places.first()
         self.assertEqual(historical_place.place, self.place)
 
     def test_clear(self):
@@ -1576,11 +1576,11 @@ class ManyToManyTest(TestCase):
 
         # Most recent should have 4 places
         m2m_record = self.poll.history.all()[0]
-        self.assertEqual(m2m_record.historical_places.all().count(), 4)
+        self.assertEqual(m2m_record.places.all().count(), 4)
 
         # Previous one should have 3
         prev_record = m2m_record.prev_record
-        self.assertEqual(prev_record.historical_places.all().count(), 3)
+        self.assertEqual(prev_record.places.all().count(), 3)
 
         # Clear all places
         self.poll.places.clear()
@@ -1590,7 +1590,7 @@ class ManyToManyTest(TestCase):
 
         # Most recent should have no places
         m2m_record = self.poll.history.all()[0]
-        self.assertEqual(m2m_record.historical_places.all().count(), 0)
+        self.assertEqual(m2m_record.places.all().count(), 0)
 
     def test_delete_child(self):
         # Add a place
@@ -1606,15 +1606,15 @@ class ManyToManyTest(TestCase):
 
         # The newest row still has a place attached to it
         m2m_record = self.poll.history.all()[0]
-        self.assertEqual(m2m_record.historical_places.count(), 1)
+        self.assertEqual(m2m_record.places.count(), 1)
 
         # Place instance cannot be created...
-        historical_place = m2m_record.historical_places.first()
+        historical_place = m2m_record.places.first()
         with self.assertRaises(ObjectDoesNotExist):
             historical_place.place.id
 
         # But the values persist
-        historical_place_values = m2m_record.historical_places.all().values()[0]
+        historical_place_values = m2m_record.places.all().values()[0]
         self.assertEqual(historical_place_values['history_id'], m2m_record.history_id)
         self.assertEqual(historical_place_values['place_id'], original_place_id)
         self.assertEqual(
@@ -1636,14 +1636,14 @@ class ManyToManyTest(TestCase):
 
         # Confirm the newest row (the delete) has no relations
         m2m_record = self.model.history.all()[0]
-        self.assertEqual(m2m_record.historical_places.count(), 0)
+        self.assertEqual(m2m_record.places.count(), 0)
 
         # Confirm the previous row still has one
         prev_record = m2m_record.prev_record
-        self.assertEqual(prev_record.historical_places.count(), 1)
+        self.assertEqual(prev_record.places.count(), 1)
 
         # And it is the correct one
-        historical_place = prev_record.historical_places.first()
+        historical_place = prev_record.places.first()
         self.assertEqual(historical_place.place, self.place)
 
     def test_update_child(self):
@@ -1660,8 +1660,8 @@ class ManyToManyTest(TestCase):
 
         # The newest row has the updated place
         m2m_record = self.poll.history.all()[0]
-        self.assertEqual(m2m_record.historical_places.count(), 1)
-        historical_place = m2m_record.historical_places.first()
+        self.assertEqual(m2m_record.places.count(), 1)
+        historical_place = m2m_record.places.first()
         self.assertEqual(historical_place.place.name, "Updated")
 
     def test_update_parent(self):
@@ -1678,8 +1678,8 @@ class ManyToManyTest(TestCase):
 
         # The newest row still has the associated Place
         m2m_record = self.poll.history.all()[0]
-        self.assertEqual(m2m_record.historical_places.count(), 1)
-        historical_place = m2m_record.historical_places.first()
+        self.assertEqual(m2m_record.places.count(), 1)
+        historical_place = m2m_record.places.first()
         self.assertEqual(historical_place.place, self.place)
 
     def test_bulk_add_remove(self):
@@ -1696,11 +1696,11 @@ class ManyToManyTest(TestCase):
 
         # Most recent should have 4 places
         m2m_record = self.poll.history.all()[0]
-        self.assertEqual(m2m_record.historical_places.all().count(), 4)
+        self.assertEqual(m2m_record.places.all().count(), 4)
 
         # Previous one should have 0
         prev_record = m2m_record.prev_record
-        self.assertEqual(prev_record.historical_places.all().count(), 0)
+        self.assertEqual(prev_record.places.all().count(), 0)
 
         # Remove all places but the first
         self.poll.places.remove(*Place.objects.filter(id__gt=1))
@@ -1709,10 +1709,77 @@ class ManyToManyTest(TestCase):
 
         # Most recent should only have the first Place remaining
         m2m_record = self.poll.history.all()[0]
-        self.assertEqual(m2m_record.historical_places.all().count(), 1)
+        self.assertEqual(m2m_record.places.all().count(), 1)
 
-        historical_place = m2m_record.historical_places.first()
+        historical_place = m2m_record.places.first()
         self.assertEqual(historical_place.place, self.place)
+
+    def test_m2m_relation(self):
+        # Ensure only the correct M2Ms are saved and returned for history objects
+        poll_2 = PollWithManyToMany.objects.create(question="Why", pub_date=today)
+        place_2 = Place.objects.create(name="Place 2")
+
+        poll_2.places.add(self.place)
+        poll_2.places.add(place_2)
+
+        self.assertEqual(self.poll.history.all()[0].places.count(), 0)
+        self.assertEqual(poll_2.history.all()[0].places.count(), 2)
+
+    def test_skip_history(self):
+        skip_poll = PollWithManyToMany.objects.create(
+            question="skip history?", pub_date=today
+        )
+        self.assertEqual(self.poll.history.all().count(), 1)
+        self.assertEqual(self.poll.history.all()[0].places.count(), 0)
+
+        skip_poll.skip_history_when_saving = True
+
+        skip_poll.question = "huh?"
+        skip_poll.save()
+        skip_poll.places.add(self.place)
+
+        self.assertEqual(self.poll.history.all().count(), 1)
+        self.assertEqual(self.poll.history.all()[0].places.count(), 0)
+
+        del skip_poll.skip_history_when_saving
+        place_2 = Place.objects.create(name="Place 2")
+
+        skip_poll.places.add(place_2)
+
+        self.assertEqual(skip_poll.history.all().count(), 2)
+        self.assertEqual(skip_poll.history.all()[0].places.count(), 2)
+
+    def test_diff_against(self):
+        self.poll.places.add(self.place)
+        add_record, create_record = self.poll.history.all()
+
+        delta = add_record.diff_against(create_record)
+        expected_change = ModelChange("places", [], [(1, 1, 2, 1, 1)])
+        self.assertEqual(delta.changed_fields, ["places"])
+        self.assertEqual(delta.old_record, create_record)
+        self.assertEqual(delta.new_record, add_record)
+        self.assertEqual(expected_change.field, delta.changes[0].field)
+
+        self.assertListEqual(expected_change.new, delta.changes[0].new)
+        self.assertListEqual(expected_change.old, delta.changes[0].old)
+
+        self.poll.places.clear()
+
+        # First and third records are effectively the same.
+        del_record, add_record, create_record = self.poll.history.all()
+        delta = del_record.diff_against(create_record)
+        self.assertNotIn("places", delta.changed_fields)
+
+        # Second and third should have the same diffs as first and second, but with
+        # old and new reversed
+        expected_change = ModelChange("places", [(1, 1, 2, 1, 1)], [])
+        delta = del_record.diff_against(add_record)
+        self.assertEqual(delta.changed_fields, ["places"])
+        self.assertEqual(delta.old_record, add_record)
+        self.assertEqual(delta.new_record, del_record)
+        self.assertEqual(expected_change.field, delta.changes[0].field)
+        self.assertListEqual(expected_change.new, delta.changes[0].new)
+        self.assertListEqual(expected_change.old, delta.changes[0].old)
 
 
 @override_settings(**database_router_override_settings)

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -1488,7 +1488,7 @@ class ManyToManyTest(TestCase):
     def setUp(self):
         self.model = PollWithManyToMany
         self.history_model = self.model.history.model
-        self.place = Place.objects.create(name='Home')
+        self.place = Place.objects.create(name="Home")
         self.poll = PollWithManyToMany.objects.create(
             question="what's up?", pub_date=today
         )
@@ -1539,7 +1539,7 @@ class ManyToManyTest(TestCase):
 
         # And the historical place is the correct one
         historical_place = m2m_record.historical_places.first()
-        self.assertEqual(historical_place.place, self.place.id)
+        self.assertEqual(historical_place.place, self.place)
 
     def test_remove(self):
         # Add and remove a many-to-many child
@@ -1559,7 +1559,7 @@ class ManyToManyTest(TestCase):
 
         # And the previous row still has the correct one
         historical_place = previous_m2m_record.historical_places.first()
-        self.assertEqual(historical_place.place, self.place.id)
+        self.assertEqual(historical_place.place, self.place)
 
     def test_clear(self):
         # Add some places
@@ -1608,9 +1608,19 @@ class ManyToManyTest(TestCase):
         m2m_record = self.poll.history.all()[0]
         self.assertEqual(m2m_record.historical_places.count(), 1)
 
-        # place is just the ID of the original Place instance
+        # Place instance cannot be created...
         historical_place = m2m_record.historical_places.first()
-        self.assertEqual(historical_place.place, original_place_id)
+        with self.assertRaises(ObjectDoesNotExist):
+            x = historical_place.place.id
+
+        # But the values persist
+        historical_place_values = m2m_record.historical_places.all().values()[0]
+        self.assertEqual(historical_place_values['history_id'], m2m_record.history_id)
+        self.assertEqual(historical_place_values['place_id'], original_place_id)
+        self.assertEqual(
+            historical_place_values['pollwithmanytomany_id'],
+            self.poll.id
+        )
 
     def test_delete_parent(self):
         # Add a place
@@ -1634,7 +1644,7 @@ class ManyToManyTest(TestCase):
 
         # And it is the correct one
         historical_place = prev_record.historical_places.first()
-        self.assertEqual(historical_place.place, self.place.id)
+        self.assertEqual(historical_place.place, self.place)
 
     def test_update_child(self):
         self.poll.places.add(self.place)
@@ -1652,7 +1662,7 @@ class ManyToManyTest(TestCase):
         m2m_record = self.poll.history.all()[0]
         self.assertEqual(m2m_record.historical_places.count(), 1)
         historical_place = m2m_record.historical_places.first()
-        self.assertEqual(Place.objects.get(pk=historical_place.place).name, "Updated")
+        self.assertEqual(historical_place.place.name, "Updated")
 
     def test_update_parent(self):
         self.poll.places.add(self.place)
@@ -1670,7 +1680,7 @@ class ManyToManyTest(TestCase):
         m2m_record = self.poll.history.all()[0]
         self.assertEqual(m2m_record.historical_places.count(), 1)
         historical_place = m2m_record.historical_places.first()
-        self.assertEqual(historical_place.place, self.place.id)
+        self.assertEqual(historical_place.place, self.place)
 
     def test_bulk_add_remove(self):
         # Add some places
@@ -1702,7 +1712,7 @@ class ManyToManyTest(TestCase):
         self.assertEqual(m2m_record.historical_places.all().count(), 1)
 
         historical_place = m2m_record.historical_places.first()
-        self.assertEqual(historical_place.place, self.place.id)
+        self.assertEqual(historical_place.place, self.place)
 
 
 @override_settings(**database_router_override_settings)

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -80,6 +80,8 @@ from ..models import (
     PollWithExcludedFieldsWithDefaults,
     PollWithExcludedFKField,
     PollWithHistoricalIPAddress,
+    PollWithManyToMany,
+    HistoricalPollWithManyToMany_places,
     Province,
     Restaurant,
     SelfFK,
@@ -1480,6 +1482,227 @@ class ForeignKeyToSelfTest(TestCase):
         self.assertEqual(
             self.model, self.history_model.fk_to_self_using_str.field.remote_field.model
         )
+
+
+class ManyToManyTest(TestCase):
+    def setUp(self):
+        self.model = PollWithManyToMany
+        self.history_model = self.model.history.model
+        self.place = Place.objects.create(name='Home')
+        self.poll = PollWithManyToMany.objects.create(
+            question="what's up?", pub_date=today
+        )
+
+    def assertDatetimesEqual(self, time1, time2):
+        self.assertAlmostEqual(time1, time2, delta=timedelta(seconds=2))
+
+    def assertRecordValues(self, record, klass, values_dict):
+        for key, value in values_dict.items():
+            self.assertEqual(getattr(record, key), value)
+        self.assertEqual(record.history_object.__class__, klass)
+        for key, value in values_dict.items():
+            if key not in ["history_type", "history_change_reason"]:
+                self.assertEqual(getattr(record.history_object, key), value)
+
+    def test_create(self):
+        # There should be 1 history record for our poll, the create from setUp
+        self.assertEqual(self.poll.history.all().count(), 1)
+
+        # The created history row should be normal and correct
+        (record,) = self.poll.history.all()
+        self.assertRecordValues(
+            record,
+            self.model,
+            {
+                "question": "what's up?",
+                "pub_date": today,
+                "id": self.poll.id,
+                "history_type": "+",
+            },
+        )
+        self.assertDatetimesEqual(record.history_date, datetime.now())
+
+        historical_poll = self.poll.history.most_recent()
+
+        # There should be no places associated with the current poll yet
+        self.assertEqual(historical_poll.historical_places.count(), 0)
+
+        # Add a many-to-many child
+        self.poll.places.add(self.place)
+
+        # A new history row has been created by adding the M2M
+        self.assertEqual(self.poll.history.all().count(), 2)
+
+        # The new row has a place attached to it
+        m2m_record = self.poll.history.most_recent()
+        self.assertEqual(m2m_record.places.count(), 1)
+
+        # And the historical place is the correct one
+        historical_place = m2m_record.historical_places.first()
+        self.assertEqual(historical_place.place, self.place.id)
+
+    def test_remove(self):
+        # Add and remove a many-to-many child
+        self.poll.places.add(self.place)
+        self.poll.places.remove(self.place)
+
+        # Two new history exist for the place add & remove
+        self.assertEqual(self.poll.history.all().count(), 3)
+
+        # The newest row has no place attached to it
+        m2m_record = self.poll.history.all()[0]
+        self.assertEqual(m2m_record.historical_places.count(), 0)
+
+        # The previous one should have one place
+        previous_m2m_record = m2m_record.prev_record
+        self.assertEqual(previous_m2m_record.historical_places.count(), 1)
+
+        # And the previous row still has the correct one
+        historical_place = previous_m2m_record.historical_places.first()
+        self.assertEqual(historical_place.place, self.place.id)
+
+    def test_clear(self):
+        # Add some places
+        place_2 = Place.objects.create(name="Place 2")
+        place_3 = Place.objects.create(name="Place 3")
+        place_4 = Place.objects.create(name="Place 4")
+        self.poll.places.add(self.place)
+        self.poll.places.add(place_2)
+        self.poll.places.add(place_3)
+        self.poll.places.add(place_4)
+
+        # Should be 5 history rows, one for the create, one from each add
+        self.assertEqual(self.poll.history.all().count(), 5)
+
+        # Most recent should have 4 places
+        m2m_record = self.poll.history.all()[0]
+        self.assertEqual(m2m_record.historical_places.all().count(), 4)
+
+        # Previous one should have 3
+        prev_record = m2m_record.prev_record
+        self.assertEqual(prev_record.historical_places.all().count(), 3)
+
+        # Clear all places
+        self.poll.places.clear()
+
+        # Clearing M2M should create a new history entry
+        self.assertEqual(self.poll.history.all().count(), 6)
+
+        # Most recent should have no places
+        m2m_record = self.poll.history.all()[0]
+        self.assertEqual(m2m_record.historical_places.all().count(), 0)
+
+    def test_delete_child(self):
+        # Add a place
+        original_place_id = self.place.id
+        self.poll.places.add(self.place)
+        self.assertEqual(self.poll.history.all().count(), 2)
+
+        # Delete the place instance
+        self.place.delete()
+
+        # No new history row is created when the Place is deleted
+        self.assertEqual(self.poll.history.all().count(), 2)
+
+        # The newest row still has a place attached to it
+        m2m_record = self.poll.history.all()[0]
+        self.assertEqual(m2m_record.historical_places.count(), 1)
+
+        # place is just the ID of the original Place instance
+        historical_place = m2m_record.historical_places.first()
+        self.assertEqual(historical_place.place, original_place_id)
+
+    def test_delete_parent(self):
+        # Add a place
+        self.poll.places.add(self.place)
+        self.assertEqual(self.poll.history.all().count(), 2)
+
+        # Delete the poll instance
+        self.poll.delete()
+
+        # History row is created when the Poll is deleted, but all m2m relations have
+        # been deleted
+        self.assertEqual(self.model.history.all().count(), 3)
+
+        # Confirm the newest row (the delete) has no relations
+        m2m_record = self.model.history.all()[0]
+        self.assertEqual(m2m_record.historical_places.count(), 0)
+
+        # Confirm the previous row still has one
+        prev_record = m2m_record.prev_record
+        self.assertEqual(prev_record.historical_places.count(), 1)
+
+        # And it is the correct one
+        historical_place = prev_record.historical_places.first()
+        self.assertEqual(historical_place.place, self.place.id)
+
+    def test_update_child(self):
+        self.poll.places.add(self.place)
+
+        # Only two history rows, one for create and one for the M2M add
+        self.assertEqual(self.poll.history.all().count(), 2)
+
+        self.place.name = "Updated"
+        self.place.save()
+
+        # Updating the referenced M2M does not add history
+        self.assertEqual(self.poll.history.all().count(), 2)
+
+        # The newest row has the updated place
+        m2m_record = self.poll.history.all()[0]
+        self.assertEqual(m2m_record.historical_places.count(), 1)
+        historical_place = m2m_record.historical_places.first()
+        self.assertEqual(Place.objects.get(pk=historical_place.place).name, "Updated")
+
+    def test_update_parent(self):
+        self.poll.places.add(self.place)
+
+        # Only two history rows, one for create and one for the M2M add
+        self.assertEqual(self.poll.history.all().count(), 2)
+
+        self.poll.question = "Updated?"
+        self.poll.save()
+
+        # Updating the model with the M2M on it creates new history
+        self.assertEqual(self.poll.history.all().count(), 3)
+
+        # The newest row still has the associated Place
+        m2m_record = self.poll.history.all()[0]
+        self.assertEqual(m2m_record.historical_places.count(), 1)
+        historical_place = m2m_record.historical_places.first()
+        self.assertEqual(historical_place.place, self.place.id)
+
+    def test_bulk_add_remove(self):
+        # Add some places
+        place_2 = Place.objects.create(name="Place 2")
+        place_3 = Place.objects.create(name="Place 3")
+        place_4 = Place.objects.create(name="Place 4")
+
+        # Bulk add all of the places
+        self.poll.places.add(*Place.objects.all())
+
+        # Should be 2 history rows, one for the create, one from the bulk add
+        self.assertEqual(self.poll.history.all().count(), 2)
+
+        # Most recent should have 4 places
+        m2m_record = self.poll.history.all()[0]
+        self.assertEqual(m2m_record.historical_places.all().count(), 4)
+
+        # Previous one should have 0
+        prev_record = m2m_record.prev_record
+        self.assertEqual(prev_record.historical_places.all().count(), 0)
+
+        # Remove all places but the first
+        self.poll.places.remove(*Place.objects.filter(id__gt=1))
+
+        self.assertEqual(self.poll.history.all().count(), 3)
+
+        # Most recent should only have the first Place remaining
+        m2m_record = self.poll.history.all()[0]
+        self.assertEqual(m2m_record.historical_places.all().count(), 1)
+
+        historical_place = m2m_record.historical_places.first()
+        self.assertEqual(historical_place.place, self.place.id)
 
 
 @override_settings(**database_router_override_settings)

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{27,34,35,36,37}-django111,
-    py{34,35,36,37}-django20,
+    py{27,35,36,37}-django111,
+    py{35,36,37}-django20,
     py{35,36,37}-django21,
     py{35,36,37,38}-django22,
     py{36,37,38}-django30,


### PR DESCRIPTION
Work in progress. Needs code cleanup, documentation added, and further testing (especially in the admin site) but seems to work as expected.

Adds support for Django's default many-to-many models (ones without explicit an `through`)

## Description
Allows m2m fields to be explicitly added to the history of a model which uses `HistoricalRecords`. It allows access to the m2m history via a `historical_{m2m_field_name}` attribute.

When the parent model adds a history row, all connected m2m fields store all existing connections with a FK back to the history row. When the m2m mapping is updated (`add`, `remove`, `clear`) a new history row is created, firing off the same process.

## Related Issue
https://github.com/treyhunner/django-simple-history/issues/399
https://github.com/treyhunner/django-simple-history/pull/370
https://github.com/treyhunner/django-simple-history/issues/16

## Motivation and Context
We need to track changes in many-to-many relationships over time. 

## How Has This Been Tested?
Added unit tests to cover everything I could think of.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run the `make format` command to format my code
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
